### PR TITLE
fix timestamp to milli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/trifonovmixail/jira-hooks
+
+go 1.18

--- a/objects/datetime.go
+++ b/objects/datetime.go
@@ -40,6 +40,6 @@ func (t *Timestamp) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	*t = Timestamp(time.Unix(i, 0))
+	*t = Timestamp(time.UnixMilli(i))
 	return nil
 }


### PR DESCRIPTION
Jira webhooks set timestamp as a milli second now, here is an example in the official document:
- https://developer.atlassian.com/cloud/jira/platform/webhooks/#webhook-payload
